### PR TITLE
Registrar pedido

### DIFF
--- a/Controladores/menu/AlimentosController.cs
+++ b/Controladores/menu/AlimentosController.cs
@@ -1,7 +1,11 @@
 ﻿namespace TACOS.Controladores.menu
 {
     using Microsoft.AspNetCore.Mvc;
+    using Newtonsoft.Json;
+    using TACOS.Modelos;
     using TACOS.Negocio.Interfaces;
+    using TACOS.Negocio;
+
 
     [ApiController]
     [Route("menu/[controller]")]
@@ -20,9 +24,28 @@
         [HttpGet(Name = "GetAlimentos")]
         public IActionResult ObtenerAlimentos()
         {
-            
-
             return new JsonResult(_menuMgr.ObtenerAlimentos()) { StatusCode = 202 };
         }
+
+        [HttpPatch("{idAlimento}, {cantidad}",Name = "ActualizarExistencia")]
+        public IActionResult ActualizarExistencia(int idAlimento, int cantidad)
+        {
+            try
+            {
+                return new JsonResult(this._menuMgr.ActualizarExistencia(
+                    new Alimentospedido() { IdAlimento = idAlimento, Cantidad = cantidad}
+                ));
+            }
+            catch (KeyNotFoundException knfException)
+            {
+                return new JsonResult(new Error { Mensaje = knfException.Message }) { StatusCode = 404 };
+            }
+            catch (ArgumentException aException)
+            {
+                return new JsonResult(new Error { Mensaje = aException.Message }) { StatusCode = 409 };
+            }
+        }
+
+
     }
 }

--- a/Controladores/personas/MiembrosController.cs
+++ b/Controladores/personas/MiembrosController.cs
@@ -22,9 +22,7 @@ namespace TACOS.Controladores.personas
 
         [HttpPost(Name = "PostMiembros")]
         public IActionResult IniciarSesion([FromBody] Credenciales credenciales)
-        {
-            Console.WriteLine("iniciar sesion en controller");
-            
+        {            
             try
             {
                 return new JsonResult(this._consultanteMgr.IniciarSesion(credenciales));

--- a/Controladores/personas/PedidosController.cs
+++ b/Controladores/personas/PedidosController.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using TACOS.Modelos;
 using TACOS.Negocio.Interfaces;
+using TACOS.Negocio;
 
 namespace TACOS.Controladores.personas
 {
@@ -18,10 +20,18 @@ namespace TACOS.Controladores.personas
             _menuMgr = menuMgr;
         }
 
-        [HttpPost(Name = "PostPedido")]
-        public void RegistrarPedido()
+        [HttpPost(Name = "RegistrarPedido")]
+        public IActionResult RegistrarPedido([FromBody] Pedido pedido)
         {
-            _menuMgr.RegistrarPedido();
+            try
+            {
+                return new JsonResult(_menuMgr.RegistrarPedido(pedido));
+            }
+            catch (Exception exception)
+            {
+                return new JsonResult(new Error { Mensaje = exception.Message}) { StatusCode = 500};
+            }
+            
         }
     }
 }

--- a/Modelos/Alimento.cs
+++ b/Modelos/Alimento.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace TACOS.Modelos;
@@ -17,13 +18,13 @@ public partial class Alimento
 
     public double? Precio { get; set; }
 
-    public DateTime CreatedAt { get; set; }
-
-    public DateTime UpdatedAt { get; set; }
-
     public int IdCategoria { get; set; }
 
+    [JsonIgnore]
     public virtual ICollection<Alimentospedido> Alimentospedidos { get; set; } = new List<Alimentospedido>();
 
+    [JsonIgnore]
     public virtual Categorium IdCategoriaNavigation { get; set; } = null!;
+    
+
 }

--- a/Modelos/Alimentospedido.cs
+++ b/Modelos/Alimentospedido.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿
+using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace TACOS.Modelos;
 
@@ -9,15 +11,13 @@ public partial class Alimentospedido
 
     public int? Cantidad { get; set; }
 
-    public DateTime CreatedAt { get; set; }
-
-    public DateTime UpdatedAt { get; set; }
-
     public int IdAlimento { get; set; }
 
     public int IdPedido { get; set; }
 
-    public virtual Alimento IdAlimentoNavigation { get; set; } = null!;
+    [JsonIgnore]
+    public Alimento? IdAlimentoNavigation { get; set; } = null!;
 
-    public virtual Pedido IdPedidoNavigation { get; set; } = null!;
+    [JsonIgnore]
+    public Pedido? IdPedidoNavigation { get; set; } = null!;
 }

--- a/Modelos/Categorium.cs
+++ b/Modelos/Categorium.cs
@@ -9,10 +9,6 @@ public partial class Categorium
 
     public string? Nombre { get; set; }
 
-    public DateTime CreatedAt { get; set; }
-
-    public DateTime UpdatedAt { get; set; }
-
     public string? Medida { get; set; }
 
     public virtual ICollection<Alimento> Alimentos { get; set; } = new List<Alimento>();

--- a/Modelos/Miembro.cs
+++ b/Modelos/Miembro.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace TACOS.Modelos;
 
@@ -11,13 +12,10 @@ public partial class Miembro
 
     public int? PedidosPagados { get; set; }
 
-    public DateTime CreatedAt { get; set; }
-
-    public DateTime UpdatedAt { get; set; }
-
     public int IdPersona { get; set; }
 
     public Persona Persona { get; set; } = null!;
 
+    [JsonIgnore]
     public virtual ICollection<Pedido> Pedidos { get; set; } = new List<Pedido>();
 }

--- a/Modelos/Pedido.cs
+++ b/Modelos/Pedido.cs
@@ -9,9 +9,7 @@ public partial class Pedido
 
     public double? Total { get; set; }
 
-    public DateTime CreatedAt { get; set; }
-
-    public DateTime UpdatedAt { get; set; }
+    public DateTime Fecha { get; set; }
 
     public int IdMiembro { get; set; }
 
@@ -19,5 +17,5 @@ public partial class Pedido
 
     public virtual ICollection<Alimentospedido> Alimentospedidos { get; set; } = new List<Alimentospedido>();
 
-    public virtual Miembro IdMiembroNavigation { get; set; } = null!;
+    public virtual Miembro? IdMiembroNavigation { get; set; } = null!;
 }

--- a/Modelos/Persona.cs
+++ b/Modelos/Persona.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿
+using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace TACOS.Modelos;
 
@@ -19,9 +21,6 @@ public partial class Persona
 
     public string Telefono { get; set; } = null!;
 
-    public DateTime CreatedAt { get; set; }
-
-    public DateTime UpdatedAt { get; set; }
-
+    [JsonIgnore]
     public ICollection<Miembro> Miembros { get; set; } = new List<Miembro>();
 }

--- a/Modelos/TacosdbContext.cs
+++ b/Modelos/TacosdbContext.cs
@@ -46,9 +46,6 @@ public partial class TacosdbContext : DbContext
             entity.HasIndex(e => e.IdCategoria, "idCategoria");
 
             entity.Property(e => e.Id).HasColumnName("id");
-            entity.Property(e => e.CreatedAt)
-                .HasColumnType("datetime")
-                .HasColumnName("createdAt");
             entity.Property(e => e.Descripcion)
                 .HasMaxLength(1000)
                 .HasColumnName("descripcion");
@@ -61,9 +58,6 @@ public partial class TacosdbContext : DbContext
                 .HasMaxLength(50)
                 .HasColumnName("nombre");
             entity.Property(e => e.Precio).HasColumnName("precio");
-            entity.Property(e => e.UpdatedAt)
-                .HasColumnType("datetime")
-                .HasColumnName("updatedAt");
 
             entity.HasOne(d => d.IdCategoriaNavigation).WithMany(p => p.Alimentos)
                 .HasForeignKey(d => d.IdCategoria)
@@ -83,14 +77,8 @@ public partial class TacosdbContext : DbContext
 
             entity.Property(e => e.Id).HasColumnName("id");
             entity.Property(e => e.Cantidad).HasColumnName("cantidad");
-            entity.Property(e => e.CreatedAt)
-                .HasColumnType("datetime")
-                .HasColumnName("createdAt");
             entity.Property(e => e.IdAlimento).HasColumnName("idAlimento");
             entity.Property(e => e.IdPedido).HasColumnName("idPedido");
-            entity.Property(e => e.UpdatedAt)
-                .HasColumnType("datetime")
-                .HasColumnName("updatedAt");
 
             entity.HasOne(d => d.IdAlimentoNavigation).WithMany(p => p.Alimentospedidos)
                 .HasForeignKey(d => d.IdAlimento)
@@ -110,18 +98,12 @@ public partial class TacosdbContext : DbContext
             entity.ToTable("categoria");
 
             entity.Property(e => e.Id).HasColumnName("id");
-            entity.Property(e => e.CreatedAt)
-                .HasColumnType("datetime")
-                .HasColumnName("createdAt");
             entity.Property(e => e.Medida)
                 .HasMaxLength(30)
                 .HasColumnName("medida");
             entity.Property(e => e.Nombre)
                 .HasMaxLength(30)
                 .HasColumnName("nombre");
-            entity.Property(e => e.UpdatedAt)
-                .HasColumnType("datetime")
-                .HasColumnName("updatedAt");
         });
 
         modelBuilder.Entity<Miembro>(entity =>
@@ -136,15 +118,8 @@ public partial class TacosdbContext : DbContext
             entity.Property(e => e.Contrasena)
                 .HasMaxLength(255)
                 .HasColumnName("contrasena");
-            entity.Property(e => e.CreatedAt)
-                .HasColumnType("datetime")
-                .HasColumnName("createdAt");
             entity.Property(e => e.IdPersona).HasColumnName("idPersona");
             entity.Property(e => e.PedidosPagados).HasColumnName("pedidosPagados");
-            entity.Property(e => e.UpdatedAt)
-                .HasColumnType("datetime")
-                .HasColumnName("updatedAt");
-
             
             entity.HasOne(d => d.Persona).WithMany(p => p.Miembros)
                 .HasForeignKey(d => d.IdPersona)
@@ -161,17 +136,15 @@ public partial class TacosdbContext : DbContext
             entity.HasIndex(e => e.IdMiembro, "idMiembro");
 
             entity.Property(e => e.Id).HasColumnName("id");
-            entity.Property(e => e.CreatedAt)
-                .HasColumnType("datetime")
-                .HasColumnName("createdAt");
+
             entity.Property(e => e.Estado)
                 .HasMaxLength(255)
                 .HasColumnName("estado");
             entity.Property(e => e.IdMiembro).HasColumnName("idMiembro");
             entity.Property(e => e.Total).HasColumnName("total");
-            entity.Property(e => e.UpdatedAt)
+            entity.Property(e => e.Fecha)
                 .HasColumnType("datetime")
-                .HasColumnName("updatedAt");
+                .HasColumnName("fecha");
 
             entity.HasOne(d => d.IdMiembroNavigation).WithMany(p => p.Pedidos)
                 .HasForeignKey(d => d.IdMiembro)
@@ -194,9 +167,6 @@ public partial class TacosdbContext : DbContext
             entity.Property(e => e.ApellidoPaterno)
                 .HasMaxLength(255)
                 .HasColumnName("apellidoPaterno");
-            entity.Property(e => e.CreatedAt)
-                .HasColumnType("datetime")
-                .HasColumnName("createdAt");
             entity.Property(e => e.Direccion)
                 .HasMaxLength(255)
                 .HasColumnName("direccion");
@@ -207,9 +177,6 @@ public partial class TacosdbContext : DbContext
             entity.Property(e => e.Telefono)
                 .HasMaxLength(255)
                 .HasColumnName("telefono");
-            entity.Property(e => e.UpdatedAt)
-                .HasColumnType("datetime")
-                .HasColumnName("updatedAt");
         });
 
         OnModelCreatingPartial(modelBuilder);

--- a/Negocio/Interfaces/IMenuMgt.cs
+++ b/Negocio/Interfaces/IMenuMgt.cs
@@ -5,6 +5,7 @@ namespace TACOS.Negocio.Interfaces
     public interface IMenuMgt
     {
         public List<Alimento> ObtenerAlimentos();
-        public void RegistrarPedido();
+        public int ActualizarExistencia(Alimentospedido alimento);
+        public bool RegistrarPedido(Pedido nuevoPedido);
     }
 }

--- a/Negocio/MenuMgr.cs
+++ b/Negocio/MenuMgr.cs
@@ -3,11 +3,29 @@ using System.Collections.Generic;
 using System.Globalization;
 using TACOS.Negocio.Interfaces;
 using TACOS.Modelos;
+using Microsoft.AspNetCore.Http.HttpResults;
 
 public class MenuMgr : ManagerBase, IMenuMgt
 {
     public MenuMgr(TacosdbContext tacosdbContext) : base(tacosdbContext)
     {
+    }
+
+    public int ActualizarExistencia(Alimentospedido alimento)
+    {
+        Alimento? alimentoEncontrado = 
+            this.tacosdbContext.Alimentos.FirstOrDefault(a => a.Id == alimento.IdAlimento);
+        if (alimentoEncontrado is null)
+        {
+            throw new KeyNotFoundException("No se encontró el alimento solicitado.");
+        }
+        if (alimento.Cantidad < 0 && alimentoEncontrado.Existencia < 1)
+        {
+            throw new ArgumentException("El alimento solicitado no está disponible.");
+        }
+
+        alimentoEncontrado.Existencia += alimento.Cantidad;
+        return this.tacosdbContext.SaveChanges();
     }
 
     public List<Alimento> ObtenerAlimentos()
@@ -16,8 +34,9 @@ public class MenuMgr : ManagerBase, IMenuMgt
                                             .ToList();
     }
 
-    public void RegistrarPedido()
+    public bool RegistrarPedido(Pedido nuevoPedido)
     {
-        Console.WriteLine("registrar pedido!!!!");
+        this.tacosdbContext.Pedidos.Add(nuevoPedido);
+        return this.tacosdbContext.SaveChanges() > 0;
     }
 }


### PR DESCRIPTION
Cuando el server recibe un objeto JSON, intenta insertar a la base *todos* los objetos dentro del objeto JSON. Es decir, sin un pedido nuevo contiene al objeto miembro de la persona que lo hizo, el servidor intentará insertar al pedido Y al miembro del pedido.

Por esta razón:
1. Ciertas propiedades deben ser nulables; que la clase tenga un ? (public virtual Miembro? miembro)
2. Poner etiqueta [JsonIgnore] sobre atributos que no quieras que aparezcan en Swagger.  El server usa System.Text.Json.Serialization, pero el cliente debe usar Newtonsoft.Json.